### PR TITLE
Implement verb-noun linkings

### DIFF
--- a/src/examples/control_spans/example_control.py
+++ b/src/examples/control_spans/example_control.py
@@ -137,5 +137,7 @@ matchings = get_matchings(labeled_tree, matching_rules)
 
 subtree = labeled_tree[1][0][1][0]
 from itertools import product
+from .span_realization import *
 
-# surfaces = labeledtree_to_surface(labeled_tree, surf_rules, [], [])
+surfaces = labeledtree_to_surface(labeled_tree, surf_rules, [], [])
+np_spans, vp_spans, surfs = surfaces[0]

--- a/src/examples/control_spans/example_control.py
+++ b/src/examples/control_spans/example_control.py
@@ -1,5 +1,5 @@
 from ...mcfg import CategoryMeta, AbsRule, AbsGrammar
-from .span_realization import abstree_to_labeledtree, get_matchings
+from .span_realization import abstree_to_labeledtree, labeledtree_to_surface, get_matchings
 from pprint import pprint
 
 """
@@ -86,7 +86,8 @@ def default_concat(*args):
 
 annotated_rules = [
         ((S,            (CTRL,)),
-         (dict(),       (False,))),
+         (dict(),       (False,)),
+         ([(0, 0)],)),
         ((CTRL,         (NP_s, TV_su_ctrl, NP_o, VC)),
          ({1: 0},       (False, False, False, 0)),
          ([(0, 0), (1, 0), (2, 0), (3, 0)],)),
@@ -97,17 +98,23 @@ annotated_rules = [
          (dict(),       (False, True)),
          ([(0, 0), (1, 0)],)),
         ((INF,          (ITV_inf,)),
-         ({0: None},    (False,))),
+         ({0: None},    (False,)),
+         ([(0, 0)],)),
         ((VC,           (INF_tv, TE)),
-         ({0: None},    (False, False))),
+         ({0: None},    (False, False)),
+         ([(0, 0), (1, 0), (0, 1)],)),
         ((VC,           (NP_o2, TE, INF_su_ctrl, VC)),
-         ({2: None},    (False, False, False, True))),
+         ({2: None},    (False, False, False, True)),
+         ([(0, 0), (1, 0), (2, 0), (3, 0)],)),
         ((VC,           (NP_o2, TE, INF_obj_ctrl, VC)),
-         ({2: None},    (False, False, False, 0))),
+         ({2: None},    (False, False, False, 0)),
+         ([(0, 0), (1, 0), (2, 0), (3, 0)],)),
         ((NP_s,         (NP_s, DIE, NP_o, REL_su_VERB)),
-         ({3: 0},       (False, False, False, False))),
+         ({3: 0},       (False, False, False, False)),
+         ([(0, 0), (1, 0), (2, 0), (3, 0)],)),
         ((NP_s,         (NP_s, DIE, NP_o, REL_obj_VERB)),
-         ({3: 2},       (False, False, False, False)))
+         ({3: 2},       (False, False, False, False)),
+         ([(0, 0), (1, 0), (2, 0), (3, 0)],))
 ]
 
 
@@ -118,10 +125,17 @@ grammar = AbsGrammar(rules)
 trees = grammar.generate(S, 4, True)
 
 
-matching_rules = {AbsRule(lhs, rhs): matching_rule for ((lhs, rhs), matching_rule) in annotated_rules}
+matching_rules = {AbsRule(lhs, rhs): matching_rule for ((lhs, rhs), matching_rule, _) in annotated_rules}
+surf_rules = {AbsRule(lhs, rhs): surf_rule for ((lhs, rhs), _, surf_rule) in annotated_rules}
 
 n_candidates = {NP_s, NP_o, NP_o2}
 v_candidates = {TV_su_ctrl, TV_obj_ctrl, ITV_inf, INF_su_ctrl, INF_obj_ctrl, REL_su_VERB, REL_obj_VERB, INF_tv}
 
-labeled_tree = abstree_to_labeledtree(trees[0], n_candidates, v_candidates, iter(range(999)), iter(range(999)))
+abstree = trees[0]
+labeled_tree = abstree_to_labeledtree(abstree, n_candidates, v_candidates, iter(range(999)), iter(range(999)))
 matchings = get_matchings(labeled_tree, matching_rules)
+
+subtree = labeled_tree[1][0][1][0]
+from itertools import product
+
+# surfaces = labeledtree_to_surface(labeled_tree, surf_rules, [], [])

--- a/src/examples/control_spans/example_control.py
+++ b/src/examples/control_spans/example_control.py
@@ -50,7 +50,8 @@ NP_inf = CategoryMeta('NP_inf')
 
 TV_su_ctrl = CategoryMeta('TV_su_ctrl')
 TV_obj_ctrl = CategoryMeta('TV_obj_ctrl')
-INF_ctrl = CategoryMeta('INF_ctrl')
+INF_su_ctrl = CategoryMeta('INF_su_ctrl')
+INF_obj_ctrl = CategoryMeta('INF_obj_ctrl')
 ITV_inf = CategoryMeta('ITV_inf')
 TV_inf = CategoryMeta('TV_inf')
 DIE = CategoryMeta('DIE')
@@ -70,7 +71,8 @@ TV_inf.constants = ['drinken', 'eten']
 
 TV_su_ctrl.constants = ['belooft', 'garandeert']
 TV_obj_ctrl.constants = ['vraagt', 'dwingt']
-INF_ctrl.constants = ['beloven', 'vragen', 'dwingen', 'garanderen']
+INF_su_ctrl.constants = ['beloven', 'garanderen']
+INF_obj_ctrl.constants = ['vragen', 'dwingen']
 
 INF_tv.constants = [('het biertje', 'drinken'), ('een pizza', 'eten')]
 DIE.constants = ['die']
@@ -116,17 +118,10 @@ grammar = AbsGrammar(rules)
 trees = grammar.generate(S, 4, True)
 
 
-span_rules = {AbsRule(lhs, rhs): lam for ((lhs, rhs), lam) in annotated_rules}
+matching_rules = {AbsRule(lhs, rhs): matching_rule for ((lhs, rhs), matching_rule) in annotated_rules}
 
-span_constants = {TV_su_ctrl: fst, TV_obj_ctrl: snd,
-                  ITV_inf: fst, INF_ctrl: fst, REL_su_VERB: fst,
-                  REL_obj_VERB: snd, INF_tv: fst}
+n_candidates = {NP_s, NP_o, NP_o2}
+v_candidates = {TV_su_ctrl, TV_obj_ctrl, ITV_inf, INF_su_ctrl, INF_obj_ctrl, REL_su_VERB, REL_obj_VERB, INF_tv}
 
-from ..control_spans.span_realization import abstree_to_labeledtree, labeledtree_to_verbreltree, get_rule
-from pprint import pprint
-abstree = trees[0]
-labtree = abstree_to_labeledtree(abstree, set([NP_s, NP_o, NP_o2]),
-                                 set([TV_su_ctrl, TV_obj_ctrl, ITV_inf,INF_ctrl, REL_su_VERB, REL_obj_VERB,INF_tv]),
-                                 (n for n in range(1,20)),
-                                 (n for n in range(1,20)))
-verbreltree = labeledtree_to_verbreltree(labtree, None, None, span_rules, span_constants)
+labeled_tree = abstree_to_labeledtree(trees[0], n_candidates, v_candidates, iter(range(999)), iter(range(999)))
+matchings = get_matchings(labeled_tree, matching_rules)

--- a/src/examples/control_spans/example_control.py
+++ b/src/examples/control_spans/example_control.py
@@ -141,6 +141,4 @@ labtree = abstree_to_labeledtree(abstree, set([NP_s, NP_o, NP_o2]),
                                  set([TV_su_ctrl, TV_obj_ctrl, ITV_inf,INF_ctrl, REL_su_VERB, REL_obj_VERB,INF_tv]),
                                  (n for n in range(1,20)),
                                  (n for n in range(1,20)))
-
-
-# verbreltree = labeledtree_to_verbreltree(labtree, None, None, span_rules, span_constants)
+verbreltree = labeledtree_to_verbreltree(labtree, None, None, span_rules, span_constants)

--- a/src/examples/control_spans/span_realization.py
+++ b/src/examples/control_spans/span_realization.py
@@ -10,6 +10,18 @@ LabeledTree = Tree[LabeledNode]
 VerbRelNode = tuple[Maybe[tuple[int, int]], CategoryMeta]
 VerbRelTree = Tree[VerbRelNode]
 
+# (<class 'src.mcfg.S'>,
+#  ((<class 'src.mcfg.CTRL'>,
+#    ((<class 'src.mcfg.NP_s'>,
+#      (<class 'src.mcfg.NP_s'>,
+#       <class 'src.mcfg.DIE'>,
+#       <class 'src.mcfg.NP_o'>,
+#       <class 'src.mcfg.REL_su_VERB'>)),
+#     <class 'src.mcfg.TV_su_ctrl'>,
+#     <class 'src.mcfg.NP_o'>,
+#     (<class 'src.mcfg.VC'>,
+#      (<class 'src.mcfg.INF_tv'>, <class 'src.mcfg.TE'>)))),))
+
 # ((None, None, <class 'src.mcfg.S'>),
 #  (((None, None, <class 'src.mcfg.CTRL'>),
 #    (((1, None, <class 'src.mcfg.NP_s'>),
@@ -106,3 +118,10 @@ def labeledtree_to_verbreltree(tree: LabeledTree, subj_idx: Maybe[int], obj_idx:
 #         parent, children = tree
 #         return node_map(parent), tuple(map(lambda c: fmap_depthfirst(c, node_map), children))
 #
+
+def extract_verb_rels(tree: VerbRelTree) -> list[tuple[int, int]]:
+    # A VerbRelTree always has length 2
+    if isinstance(tree[1], CategoryMeta):
+        return [tree[0]] if tree[0] not is None else []
+    if isinstance(tree[1], tuple):
+        pass

--- a/src/examples/control_spans/span_realization.py
+++ b/src/examples/control_spans/span_realization.py
@@ -8,6 +8,8 @@ LabeledTree = Tree[LabeledNode]
 Matching = dict[int, int]
 MatchingRule = dict[AbsRule, tuple[dict[int, Maybe[int]], tuple[Union[bool, int], ...]]]
 SurfaceRule = dict[AbsRule, tuple[list[tuple[int, int]], ...]]
+SpanRealization = list[tuple[list[int], list[int], tuple[int, int]]]
+Realized = list[tuple[list[int], list[int], str]]
 
 
 def abstree_to_labeledtree(tree: AbsTree, n_candidates: set[CategoryMeta], v_candidates: set[CategoryMeta],
@@ -54,24 +56,6 @@ def get_matchings(tree: LabeledTree, matching_rules: MatchingRule, inheritance: 
     return ret
 
 
-# ((None, None, <class 'src.mcfg.S'>),
-#  (((None, None, <class 'src.mcfg.CTRL'>),
-#    (((0, None, <class 'src.mcfg.NP_s'>),
-#      ((1, None, <class 'src.mcfg.NP_s'>),
-#       (None, None, <class 'src.mcfg.DIE'>),
-#       (2, None, <class 'src.mcfg.NP_o'>),
-#       (None, 0, <class 'src.mcfg.REL_su_VERB'>))),
-#     (None, 1, <class 'src.mcfg.TV_su_ctrl'>),
-#     (3, None, <class 'src.mcfg.NP_o'>),
-#     ((None, None, <class 'src.mcfg.VC'>),
-#      ((None, 2, <class 'src.mcfg.INF_tv'>),
-#       (None, None, <class 'src.mcfg.TE'>))))),))
-# fn([NP_s, DIE, NP_o, REL_su_VERB, TV_su_ctrl, NP_o, INF_tv, TE]) = DATAAAA
-
-SpanRealization = list[tuple[list[int], list[int], tuple[int, int]]]
-Realized = list[tuple[list[int], list[int], str]]
-
-
 def project_tree(tree: LabeledTree) -> list[CategoryMeta]:
     if len(tree) == 3:
         return [tree[2]]
@@ -100,8 +84,8 @@ def labeled_tree_to_realization(
 
     if len(tree) == 3:
         np_idx, vp_idx, category = tree
-        _np_labels, _vp_labels = add_to_inheritance(np_labels, np_idx), add_to_inheritance(vp_labels, vp_idx)
-        return offset + 1, [[(np_labels, _vp_labels, (offset, i))] for i in range(category.arity)]
+        np_labels, vp_labels = add_to_inheritance(np_labels, np_idx), add_to_inheritance(vp_labels, vp_idx)
+        return offset + 1, [[(np_labels, vp_labels, (offset, i))] for i in range(category.arity)]
 
     (np_idx, vp_idx, category), children = tree
     np_labels = add_to_inheritance(np_labels, np_idx)

--- a/src/examples/control_spans/span_realization.py
+++ b/src/examples/control_spans/span_realization.py
@@ -1,51 +1,14 @@
 from ...mcfg import CategoryMeta, Tree, AbsTree, AbsRule
 from typing import Union, Iterator
 from typing import Optional as Maybe
-from typing import Callable
 
 
 LabeledNode = tuple[Maybe[int], Maybe[int],  CategoryMeta]
 LabeledTree = Tree[LabeledNode]
+Matching = dict[int, int]
+MatchingRule = dict[AbsRule, tuple[dict[int, Maybe[int]], tuple[Union[bool, int], ...]]]
+SurfaceRule = dict[AbsRule, tuple[list[tuple[int, int]], ...]]
 
-VerbRelNode = tuple[Maybe[tuple[int, int]], CategoryMeta]
-VerbRelTree = Tree[VerbRelNode]
-
-# (<class 'src.mcfg.S'>,
-#  ((<class 'src.mcfg.CTRL'>,
-#    ((<class 'src.mcfg.NP_s'>,
-#      (<class 'src.mcfg.NP_s'>,
-#       <class 'src.mcfg.DIE'>,
-#       <class 'src.mcfg.NP_o'>,
-#       <class 'src.mcfg.REL_su_VERB'>)),
-#     <class 'src.mcfg.TV_su_ctrl'>,
-#     <class 'src.mcfg.NP_o'>,
-#     (<class 'src.mcfg.VC'>,
-#      (<class 'src.mcfg.INF_tv'>, <class 'src.mcfg.TE'>)))),))
-
-# ((None, None, <class 'src.mcfg.S'>),
-#  (((None, None, <class 'src.mcfg.CTRL'>),
-#    (((1, None, <class 'src.mcfg.NP_s'>),
-#      ((2, None, <class 'src.mcfg.NP_s'>),
-#       (None, None, <class 'src.mcfg.DIE'>),
-#       (3, None, <class 'src.mcfg.NP_o'>),
-#       (None, 1, <class 'src.mcfg.REL_su_VERB'>))),
-#     (None, 2, <class 'src.mcfg.TV_su_ctrl'>),
-#     (4, None, <class 'src.mcfg.NP_o'>),
-#     ((None, None, <class 'src.mcfg.VC'>),
-#      ((None, 3, <class 'src.mcfg.INF_tv'>),
-#       (None, None, <class 'src.mcfg.TE'>))))),))
-
-# ((None, <class 'src.mcfg.S'>),
-#  (((None, <class 'src.mcfg.CTRL'>),
-#    (((None, <class 'src.mcfg.NP_s'>),
-#      ((None, <class 'src.mcfg.NP_s'>),
-#       (None, <class 'src.mcfg.DIE'>),
-#       (None, <class 'src.mcfg.NP_o'>),
-#       ((1, 2), <class 'src.mcfg.REL_su_VERB'>))),
-#     ((2, 1), <class 'src.mcfg.TV_su_ctrl'>),
-#     (None, <class 'src.mcfg.NP_o'>),
-#     ((None, <class 'src.mcfg.VC'>),
-#      (((3, 1), <class 'src.mcfg.INF_tv'>), (None, <class 'src.mcfg.TE'>))))),))
 
 def abstree_to_labeledtree(tree: AbsTree, n_candidates: set[CategoryMeta], v_candidates: set[CategoryMeta],
                            n_counter: Iterator[int], v_counter: Iterator[int]) -> LabeledTree:
@@ -66,13 +29,30 @@ def abstree_to_labeledtree(tree: AbsTree, n_candidates: set[CategoryMeta], v_can
         return assign_node(parent), tuple(map(_f, children))
 
 
-def get_top(tree: LabeledTree) -> CategoryMeta:
-    # if isinstance(tree, LabeledNode):
+def get_top(_tree: LabeledTree) -> LabeledNode:
+    return _tree if len(_tree) == 3 else _tree[0]
+
+
+def get_rule(category: CategoryMeta, children: tuple[LabeledTree, ...]) -> AbsRule
+    children_categories = tuple(map(lambda c: get_top(c)[-1], children))
+    return AbsRule(category, children_categories)
+
+
+def get_matchings(tree: LabeledTree, matching_rules: MatchingRule, inheritance: Maybe[int] = None) -> Matching:
     if len(tree) == 3:
-        return tree
-    # if isinstance(tree, tuple):
-    if len(tree) == 2:
-        return tree[0]
+        return {}
+    (_, _, category), children = tree
+    abs_rule = get_rule(category, children)
+    branch_matches, inheritances = matching_rules[abs_rule]
+    ret = {children[k][1]: get_top(children[v])[0] if v is not None else inheritance
+           for k, v in branch_matches.items()}
+    for child, inh in zip(children, inheritances):
+        ret.update(get_matchings(
+            child,
+            matching_rules,
+            get_top(children[inh])[0] if isinstance(inh, int) else inheritance if inh else None))
+    return ret
+
 
 
 

--- a/src/examples/control_spans/span_realization.py
+++ b/src/examples/control_spans/span_realization.py
@@ -66,9 +66,7 @@ def get_matchings(tree: LabeledTree, matching_rules: MatchingRule, inheritance: 
 #     ((None, None, <class 'src.mcfg.VC'>),
 #      ((None, 2, <class 'src.mcfg.INF_tv'>),
 #       (None, None, <class 'src.mcfg.TE'>))))),))
-
-# {1: 0, 0: 1, 2: 0}
-
+# fn([NP_s, DIE, NP_o, REL_su_VERB, TV_su_ctrl, NP_o, INF_tv, TE]) = DATAAAA
 
 SpanRealization = list[tuple[list[int], list[int], tuple[int, int]]]
 Realized = list[tuple[list[int], list[int], str]]

--- a/src/examples/control_spans/span_realization.py
+++ b/src/examples/control_spans/span_realization.py
@@ -98,7 +98,7 @@ def labeledtree_to_surface(
 
     if len(tree) == 3:
         np_idx, vp_idx, category = tree
-        _np_labels, _vp_labels = [[add_to_inheritance(np_labels, np_idx)]], [[add_to_inheritance(vp_labels, vp_idx)]]
+        _np_labels, _vp_labels = [add_to_inheritance(np_labels, np_idx)], [add_to_inheritance(vp_labels, vp_idx)]
         return tuple(map(lambda surf_options: (_np_labels, _vp_labels, [list(surf_options)]), zip(*category.constants)))
 
     (np_idx, vp_idx, category), children = tree
@@ -115,3 +115,29 @@ def labeledtree_to_surface(
     return tuple(map(construct_surface_el, surf_rule))
 
 
+# functions that map a SpanSurface to concrete data for evaluation.
+def get_span(idx: int, surf: str) -> list[int]:
+    return len(surf.split()) * [idx]
+
+
+def get_span_ids(spans: list[list[int]]):
+    return set([n for s in spans for n in s])
+
+
+def span_surface_example_to_data(spans: list[list[int]], span_idx: int, surface: tuple[str]):
+    all_spans = []
+    for span, surf in zip(spans, surface):
+        cur_idx = span_idx if span_idx in span else None
+        cur_span = get_span(cur_idx, surf)
+        all_spans.append(cur_span)
+    return [n for s in all_spans for n in s]
+
+
+def span_surface_to_data(span_surf: SpanSurface, matchings: Matching, verb_idx: int):
+    np_spans, vp_spans, surfs = span_surf
+    surf_options = list(product(*surfs))
+    all_results = []
+    for surf_opt in surf_options:
+        result = [span_surface_example_to_data(np_spans, i, surf_opt) for i in get_span_ids(np_spans)], ' '.join(surf_opt)
+        all_results.append(result)
+    return all_results

--- a/src/mcfg.py
+++ b/src/mcfg.py
@@ -55,6 +55,8 @@ class AbsRule:
     def from_list(cls, signatures: list[tuple[CategoryMeta, tuple[CategoryMeta, ...]]]):
         return list(map(lambda s: cls(*s), signatures))
 
+    def __hash__(self):
+        return hash(str(self.lhs) + str(self.rhs))
 
 T = TypeVar('T')
 Tree = Union[T, tuple[T, tuple['Tree', ...]]]

--- a/src/mcfg.py
+++ b/src/mcfg.py
@@ -6,6 +6,9 @@ from itertools import product
 class Category:
     ...
 
+    def __getitem__(self, item: int):
+        ...
+
 
 class CategoryMeta(type):
     arity:          int


### PR DESCRIPTION
Requires 4 things:
1. hashing of abstract rules
2. defining whether to grab subj or obj for a given constant (a verb)
3. defining how to carry over subj/obj for a given abstract rule
4. traversing a labeledtree into a new tree (VerbRel)

Pitfall:
We can't instance check on Labeled node because it's a generic type, hence the ugly case statements.