### PR TITLE
Exclude lazify

### DIFF
--- a/src/examples/nl_nl/example_control/example_control.py
+++ b/src/examples/nl_nl/example_control/example_control.py
@@ -124,13 +124,15 @@ grammar = AbsGrammar(AbsRule.from_list([r[0] for r in annotated_rules]))
 matching_rules = {AbsRule(lhs, rhs): matching_rule for ((lhs, rhs), matching_rule, _) in annotated_rules}
 surf_rules = {AbsRule(lhs, rhs): surf_rule for ((lhs, rhs), _, surf_rule) in annotated_rules}
 
+exclude_candidates = {DIE}
+
 def main(max_depth: int):
     trees = [tree for depth in range(max_depth) for tree in grammar.generate(goal=S, depth=depth)]
     labeled_trees = list(map(lambda t: abstree_to_labeledtree(t, n_candidates, v_candidates,
                                                               iter(range(10)), iter(range(10))), trees))
     realizations = list(map(lambda t: labeled_tree_to_realization(t, surf_rules, [], [])[1], labeled_trees))
     matchings = list(map(lambda t: get_matchings(t, matching_rules), labeled_trees))
-    choices = list(map(lambda t: get_choices(project_tree(t)), labeled_trees))
+    choices = list(map(lambda t: get_choices(project_tree(t), exclude_candidates), labeled_trees))
     realized = [[realize_span(option, span_realization[0]) for option in options]
                 for span_realization, options in zip(realizations, choices)]
     return trees, realized, matchings

--- a/src/examples/nl_nl/span_realization.py
+++ b/src/examples/nl_nl/span_realization.py
@@ -62,8 +62,13 @@ def project_tree(tree: LabeledTree) -> list[CategoryMeta]:
     return sum([project_tree(c) for c in children], [])
 
 
-def get_choices(leaves: list[CategoryMeta]) -> Iterator[tuple[Category, ...]]:
-    return filter(lambda choice: len(set(choice)) == len(choice), product(*map(lambda cat: cat.constants, leaves)))
+def has_no_duplicates(choices: list[Category], exclude: set[CategoryMeta] = []):
+    short_list = list(filter(lambda l: type(l) not in exclude, choices))
+    return len(set(short_list)) == len(short_list)
+
+
+def get_choices(leaves: list[CategoryMeta], exclude: set[CategoryMeta] = {}) -> Iterator[tuple[Category, ...]]:
+    return filter(lambda choice: has_no_duplicates(choice, exclude), product(*map(lambda cat: cat.constants, leaves)))
 
 
 def realize_span(leaves: Sequence[Category], span_realization: SpanRealization) -> Realized:


### PR DESCRIPTION
Now we can pass a set of to be excluded CategoryMeta's which may occur as duplicates (e.g. the relative pronoun category DIE)